### PR TITLE
Enable use on UUID and integer fields

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -195,5 +195,5 @@ export default defineDisplay({
       },
     },
   ],
-  types: ["string", "text"],
+  types: ["string", "text", "uuid", "integer"],
 });


### PR DESCRIPTION
Hi, I don't know whether you want this simple change, but thought I may as well make a PR in case you do as others might find it useful.

I needed the extension to work for a UUID field so that I can open up a primary key in my frontend. This works great with the URL prefix option either using URL params (e.g. `localhost/?id=<key>`) or as a simple route key (e.g. `localhost/items/<key>`).

I added integer as well as the same logic follows for integer primary keys.

Thanks for the great extension!